### PR TITLE
HVS-274 - Add _count property to BoardDTO

### DIFF
--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -22,6 +22,11 @@ export class BoardService {
             name: true,
           },
         },
+        _count: {
+          select: {
+            Tuto: true,
+          },
+        },
       },
       where: {
         AND: [

--- a/src/board/dto/board.dto.ts
+++ b/src/board/dto/board.dto.ts
@@ -12,4 +12,8 @@ export class BoardDTO {
   name: string;
   @ApiProperty({ type: BoardImage })
   boardImage: BoardImage;
+  @ApiProperty()
+  _count: {
+    Tuto: number;
+  };
 }


### PR DESCRIPTION
This pull request adds a new `_count` property to the `BoardDTO` class. The `_count` property is an object that includes a `Tuto` property of type number. This addition allows for counting the number of `Tuto` objects associated with a `BoardDTO` object.