### PR TITLE
Fix - Add ApiCreatedResponse decorator to setMetadata endpoint in TutoController

### DIFF
--- a/src/tuto/tuto.controller.ts
+++ b/src/tuto/tuto.controller.ts
@@ -12,6 +12,7 @@ import { TutoService } from './tuto.service';
 import {
   ApiBearerAuth,
   ApiBody,
+  ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
@@ -128,6 +129,9 @@ export class TutoController {
   })
   @ApiBody({
     type: SetMetadataDTO,
+  })
+  @ApiCreatedResponse({
+    type: MetadataDTO,
   })
   @Post('metadata')
   async setMetadata(


### PR DESCRIPTION
This pull request adds the `ApiCreatedResponse` decorator to the `setMetadata` endpoint in the `TutoController` file. This decorator specifies the response type as `MetadataDTO`.