### PR TITLE
Fix - Nom personalisé pour les Tiktok

### DIFF
--- a/src/tuto/tuto.service.ts
+++ b/src/tuto/tuto.service.ts
@@ -150,9 +150,11 @@ export class TutoService {
         idSocial: socialCompatibility.id,
         idBoard: b,
         title:
-          metadata.title.length > 191
-            ? metadata.title.substring(0, 188) + '...'
-            : metadata.title,
+          metadata.title == 'TikTok - Make Your Day'
+            ? 'Nom du post'
+            : metadata.title.length > 191
+              ? metadata.title.substring(0, 188) + '...'
+              : metadata.title,
         image: metadata.image,
       };
     });

--- a/src/tuto/tuto.service.ts
+++ b/src/tuto/tuto.service.ts
@@ -134,8 +134,7 @@ export class TutoService {
 
     if (socialCompatibility.name == 'tiktok') {
       const longUrl = await this.httpService.axiosRef.get(createTuto.url);
-      createTuto.url =
-        longUrl.request._redirectable._options.href.split('?')[0];
+      createTuto.url = longUrl.request._redirectable._options.href;
     }
 
     if (socialCompatibility.name == 'instagram') {


### PR DESCRIPTION
This pull request fixes the URL extraction in the TutoService and updates it to handle the metadata.title for TikTok posts. The issue with the URL extraction has been resolved by using the full URL instead of splitting it. Additionally, the TutoService now sets the title as "Nom du post" for TikTok posts with the title "TikTok - Make Your Day". Other titles are truncated if they exceed 191 characters.